### PR TITLE
Fix check failures with rlang 0.3.0

### DIFF
--- a/tests/testthat/test-head-to-head.R
+++ b/tests/testthat/test-head-to-head.R
@@ -211,8 +211,6 @@ test_that("to_h2h_mat handles not NULL `fill`", {
 
 # h2h_funs ----------------------------------------------------------------
 test_that("h2h_funs can be used with !!!", {
-  library(rlang)
-
   expect_silent(
     output <- h2h_long(cr_data, !!! h2h_funs[c("num_wins", "num_wins2")])
   )

--- a/tests/testthat/test-item-summary.R
+++ b/tests/testthat/test-item-summary.R
@@ -121,8 +121,6 @@ test_that("summarize_player works", {
 
 # summary_funs ------------------------------------------------------------
 test_that("summary_funs can be used in summarise_item", {
-  library(rlang)
-
   output <- summarise_game(input, !!! summary_funs["min_score"])
   output_ref <- summarise_game(input, min_score = min(score))
 


### PR DESCRIPTION
Hello,

We are taking a new soft-deprecation strategy in rlang 0.3.0 that is a bit more verbose than before. Warnings are issued but only when soft-deprecated functions are called from the global env *or* if the rlang package is attached. This causes problems for comperes because:

- You have `library("rlang")` calls in your tests.
- You use `expect_silent()`, which turns warnings into failures.

AFAICS there is no need for those library calls, so this patch removes them. I am planning to release rlang 0.3.0 on Friday 19th, it'd be great if you could send a quick patch release to CRAN in the meantime. Thanks!
