### PR TITLE
Use `expect_no_message()` over `expect_silent()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Suggests:
     covr,
     knitr,
     rmarkdown,
-    testthat
+    testthat (>= 3.1.6)
 VignetteBuilder:
     knitr
 Encoding: UTF-8

--- a/tests/testthat/test-head-to-head.R
+++ b/tests/testthat/test-head-to-head.R
@@ -165,7 +165,7 @@ test_that("h2h_mat handles `player` as factor", {
 })
 
 test_that("h2h_mat allows multiple Head-to-Head functions", {
-  expect_silent(h2h_mat(cr_data))
+  expect_no_message(h2h_mat(cr_data))
 
   expect_message(
     h2h_mat(
@@ -239,3 +239,4 @@ test_that("num_wins works", {
   expect_equal(num_wins(score_1, score_2, half_for_draw = TRUE), 2)
   expect_equal(num_wins(score_1, score_2, na.rm = FALSE), NA_real_)
 })
+


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

The join functions in dplyr (like `left_join()`) now return a warning by default when a row in `x` matches _multiple_ rows in `y`. While this is typical SQL behavior, it is often unexpected during data analysis (many people don't even know it is possible), so we've decided to make this a warning. In dplyr 1.1.0, you silence this warning with `multiple = "all"`. In the meantime, we need to work around a broken test of yours that was expecting no output. I've done that by swapping `expect_silent()` for `expect_no_message()`, which looks to be what you are really trying to avoid.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!