### PR TITLE
Use `relationship` on dplyr >=1.1.0.9000

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -172,14 +172,25 @@ get_matchups <- function(cr_data) {
     select("game", "player", "score")
   class(cr) <- class(tibble::tibble())
 
-  left_join(
-    x = cr,
-    y = cr,
-    by = "game",
-    suffix = c("1", "2"),
-    multiple = "all"
-  ) %>%
-    as_widecr()
+  if (utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    out <- left_join(
+      x = cr,
+      y = cr,
+      by = "game",
+      suffix = c("1", "2"),
+      relationship = "many-to-many"
+    )
+  } else {
+    out <- left_join(
+      x = cr,
+      y = cr,
+      by = "game",
+      suffix = c("1", "2"),
+      multiple = "all"
+    )
+  }
+
+  as_widecr(out)
 }
 
 


### PR DESCRIPTION
We are preparing to release dplyr 1.1.1 and this package popped up in the revdep checks.

We realized that we didn't get the `multiple` argument quite right the first time around 😞 . It was too aggressive since it warned on both one-to-many and many-to-many joins. In 1.1.1 we've made two improvements:
- `multiple` now defaults to `"all"`. The options of `NULL`, `"error"`, and `"warning"` are deprecated.
- `relationship` is a new argument to add known constraints onto the join procedure, such as `"many-to-one"`, which replaces `multiple = "error"`.

The default of `relationship` checks to see if there is a `many-to-many` relationship between the keys of `x` and `y` and will warn if one is present. This should be _much_ rarer than what we checked for before, and targets the most dangerous case that we were trying to warn the user about.

You can read all about `relationship` here https://github.com/tidyverse/dplyr/pull/6753, along with the issues linked there.

Unfortunately it does affect some tests here. You are doing one of the few cases where a many-to-many join is reasonable (i.e. a kind of self-join between `cr` to itself), but this is still pretty rare. I think the easiest thing to do is to just branch off the dplyr version that is installed and set `relationship = "many-to-many"` or `multiple = "all"` accordingly.

We plan to submit dplyr 1.1.1 in 2-3 weeks.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!